### PR TITLE
Track action occurrences by location

### DIFF
--- a/main.go
+++ b/main.go
@@ -722,11 +722,11 @@ func updateContent(content string, occurrences []ActionOccurrence, actionInfos [
 		text  string
 	}
 	repls := make([]repl, 0)
-	for i, occ := range occurrences {
-		if i >= len(actionInfos) {
+	for _, occ := range occurrences {
+		info, ok := actionInfos[occurrenceKey(occ)]
+		if !ok {
 			continue
 		}
-		info := actionInfos[i]
 		if info.Error != nil || info.SHA == "" || occ.ReplaceStart < 0 || occ.ReplaceEnd <= occ.ReplaceStart {
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -716,7 +716,7 @@ func getActionInfosForOccurrences(ctx context.Context, client *github.Client, oc
 
 func updateContent(content string, occurrences []ActionOccurrence, actionInfos []ActionInfo) string {
 	// Build replacements for occurrences with successful resolutions
-	type repl struct{
+	type repl struct {
 		start int
 		end   int
 		text  string

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,9 @@ jobs:
           driver: docker-container
       - uses: actions/upload-artifact@v4.0.0`
 
+	// Build occurrences from the input
+	occurrences := extractOccurrences(input)
+
 	actionInfos := []ActionInfo{
 		{
 			Owner:   "actions",
@@ -45,7 +48,7 @@ jobs:
 		},
 	}
 
-	result := updateContent(input, actionInfos)
+	result := updateContent(input, occurrences, actionInfos)
 
 	expected := `name: Test Workflow
 on:


### PR DESCRIPTION
Track and update GitHub Action occurrences by precise position to prevent incorrect unification and provide accurate planned updates when multiple SHAs of the same action are used.

---
<a href="https://cursor.com/background-agent?bcId=bc-36a76bb8-b76b-41db-89ae-a1228ddeca55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36a76bb8-b76b-41db-89ae-a1228ddeca55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

