### PR TITLE
Run program on all workflow files

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,3 +16,11 @@ test:
 # Convenience alias to run dry by default
 run:
 	just pin-dry
+
+# Run dry-run over all workflow files in the repo
+pin-all-dry:
+	for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+		[ -e "$$f" ] || continue
+		echo "==> $$f"
+		printf "n\n" | go run main.go "$$f"
+	done

--- a/justfile
+++ b/justfile
@@ -24,3 +24,11 @@ pin-all-dry:
 		echo "==> $$f"
 		printf "n\n" | go run main.go "$$f"
 	done
+
+# Apply over all workflow files in the repo (non-interactive)
+pin-all-apply:
+	for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+		[ -e "$$f" ] || continue
+		echo "==> $$f"
+		go run main.go --yes "$$f"
+	done

--- a/main.go
+++ b/main.go
@@ -214,6 +214,9 @@ func main() {
 	// comment to the full semver tag (e.g., v4.2.2) that the major tag currently points to.
 	expandMajorFlag := flag.Bool("expand-major", false, "Expand moving major tags (vN or N) to full semver in the version comment")
 	policyFlag := flag.String("policy", "major", "Update policy: major (default), same-major, requested")
+	// New: allow non-interactive apply
+	yesFlag := flag.Bool("yes", false, "Apply changes without prompting")
+	yesShortFlag := flag.Bool("y", false, "Alias for --yes")
 	flag.Parse()
 
 	if flag.NArg() != 1 {
@@ -289,9 +292,12 @@ func main() {
 	}
 
 	fmt.Println()
-	if !promptConfirmation(bold("Apply changes?")+" [y/N] ") {
-		fmt.Println(bold("\nNo changes applied."))
-		return
+	// Only prompt if --yes/-y not provided
+	if !(*yesFlag || *yesShortFlag) {
+		if !promptConfirmation(bold("Apply changes?")+" [y/N] ") {
+			fmt.Println(bold("\nNo changes applied."))
+			return
+		}
 	}
 
 	err = os.WriteFile(workflowFile, []byte(updatedContent), 0644)


### PR DESCRIPTION
Add `pin-all-dry` Just target to run the program on all workflow files in dry-run mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-91ff879c-6016-4099-92ee-afa55513109a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91ff879c-6016-4099-92ee-afa55513109a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

