### PR TITLE
Add conventional commits cursor rule

### DIFF
--- a/.cursor/rules/conventional-commits.md
+++ b/.cursor/rules/conventional-commits.md
@@ -1,0 +1,32 @@
+# Conventional Commits
+
+- ALWAYS write commit messages and PR titles using Conventional Commits.
+- Format: `type(scope)!: short, imperative summary`
+  - `type`: one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+  - `scope` (optional): area/package/component, e.g. `cli`, `parser`, `docs`, `release`. Prefer kebab-case.
+  - `!` (optional): use when introducing a breaking change.
+  - `summary`: imperative, present tense, no trailing period, ideally ≤ 72 chars.
+- Body (optional but recommended): why the change was made and notable details.
+- Footer (as needed):
+  - `BREAKING CHANGE: <description>` when breaking behavior.
+  - `Closes: #123` / `Refs: #123` to link issues.
+
+We use Conventional Commits to drive automated changelogs and versioning. Ensure squash-merge PRs produce a final title/body that conforms.
+
+## Examples
+
+- `feat(cli): add --config flag`
+- `fix(parser): handle empty input without panic`
+- `refactor: simplify validation flow`
+- `perf(cache)!: drop LRU in favor of ARC for better hit rate`
+
+Body example:
+
+```
+feat(release): enable release-please manifest
+
+This integrates release-please to automate version bumps and changelog
+entries based on commit types. No behavioral changes at runtime.
+
+Refs: #42
+```


### PR DESCRIPTION
Add a Cursor rule to enforce Conventional Commits for all commit messages and PR titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-4032289f-87d2-4705-83f5-3f77b5b2c85e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4032289f-87d2-4705-83f5-3f77b5b2c85e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

