### PR TITLE
Fix goreleaser config for xattr error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,8 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pin-github-actions"]
+          on_macos do
+            if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pin-github-actions"]
+            end
           end

--- a/Casks/pin-github-actions.rb
+++ b/Casks/pin-github-actions.rb
@@ -32,9 +32,11 @@ cask "pin-github-actions" do
     end
   end
 
-  postflight do
-    if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
-      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pin-github-actions"]
+  on_macos do
+    postflight do
+      if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+        system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pin-github-actions"]
+      end
     end
   end
 


### PR DESCRIPTION
Prevent `xattr` calls on Linux for Homebrew cask installations by adding macOS guards.

---
<a href="https://cursor.com/background-agent?bcId=bc-f690da04-512c-47dc-a66f-8ffc22b65041">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f690da04-512c-47dc-a66f-8ffc22b65041">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

