### PR TITLE
Speed up test job with go caching

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: '1.21'
+        go-version-file: go.mod
+        cache: true
         
     - name: Run tests
       run: go test -v ./...


### PR DESCRIPTION
Update `go-tests.yml` to use `go-version-file` and caching with `actions/setup-go` to speed up test runs.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfd30768-757e-49e7-a473-02cf9c005d3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfd30768-757e-49e7-a473-02cf9c005d3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

