### PR TITLE
Improve goreleaser install script for xattr availability

### DIFF
--- a/Casks/pin-github-actions.rb
+++ b/Casks/pin-github-actions.rb
@@ -33,7 +33,7 @@ cask "pin-github-actions" do
   end
 
   postflight do
-    if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+    if OS.mac? && File.exist?("/usr/bin/xattr")
       system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pin-github-actions"]
     end
   end


### PR DESCRIPTION
Improve Homebrew cask's `postflight` to safely handle `xattr` on macOS.

The previous check `system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0` was problematic as it assumed `xattr`'s existence and would fail on non-macOS systems or where `xattr` is not present. This change ensures the command only runs on macOS and only if `/usr/bin/xattr` is available, making the formula more robust.

---
<a href="https://cursor.com/background-agent?bcId=bc-81ecaaa9-de71-446f-902b-9e24a0a8c4d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81ecaaa9-de71-446f-902b-9e24a0a8c4d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

