### PR TITLE
Alias —write to —yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Download a tarball for your OS/arch from the project releases and place the `pin
 ## Usage
 
 ```bash
-pin-github-actions [--expand-major] [--policy <policy>] [--yes] [--dry-run] <workflow-file>
+pin-github-actions [--expand-major] [--policy <policy>] [--yes|--write] [--dry-run] <workflow-file>
 
 # Example
 pin-github-actions --policy same-major --yes .github/workflows/release.yml
@@ -56,7 +56,7 @@ Flow:
 - prints discovered actions
 - resolves versions and SHAs in parallel
 - shows a "Planned updates" preview (from → to) with line/column hints
-- prompts for confirmation before writing: `Apply changes? [y/N]` (skipped when `--yes` is provided)
+- prompts for confirmation before writing: `Apply changes? [y/N]` (skipped when `--yes`/`--write` is provided)
   - answering no leaves the file unchanged
   - answering yes writes the updated workflow file in place
 
@@ -69,10 +69,10 @@ Example replacement: `uses: actions/checkout@11bd... # v4.2.2`.
   - `major` (default): bump to the latest available version across all majors (Renovate-like "latest" behavior)
   - `same-major`: stay within the requested major and pick the latest tag for that major
   - `requested`: pin exactly the requested ref (e.g., resolve `v4` to the commit it currently points to)
-- `--yes`: Apply updates non-interactively by skipping the confirmation prompt.
+- `--yes`, `--write`: Apply updates non-interactively by skipping the confirmation prompt.
 - `--dry-run`: Perform a non-destructive preview. Prints the planned updates and exits without prompting or writing to disk.
   - Exit code 0 when no changes are needed, 2 when changes would be made (useful in CI)
-  - Mutually exclusive with `--yes`
+  - Mutually exclusive with `--yes`/`--write`
 
 ## Authentication
 

--- a/docs/feature-improvements/01-dry-run-preview.md
+++ b/docs/feature-improvements/01-dry-run-preview.md
@@ -3,5 +3,5 @@
 Provide a non-destructive mode that resolves and displays planned updates without prompting or writing to disk.
 
 - Behavior: perform full scan and resolution; print the "Planned updates" table; do not modify files; exit code 0 when no changes, 2 when changes would be made (useful in CI).
-- Flags: `--dry-run` mutually exclusive with `--yes`.
+- Flags: `--dry-run` mutually exclusive with `--yes`/`--write`.
 - Rationale: enables safe auditing and CI gating.

--- a/docs/feature-improvements/02-yes-noninteractive.md
+++ b/docs/feature-improvements/02-yes-noninteractive.md
@@ -1,4 +1,4 @@
-# Feature: Non-interactive apply (`--yes`)
+# Feature: Non-interactive apply (`--yes`/`--write`)
 
 Allow automatic application of updates without the confirmation prompt.
 

--- a/docs/feature-improvements/05-directory-and-glob.md
+++ b/docs/feature-improvements/05-directory-and-glob.md
@@ -3,5 +3,5 @@
 Allow processing many workflow files in one run.
 
 - Behavior: accept directory paths and glob patterns (e.g., `.github/workflows/*.y{a,}ml`); recurse by default for directories; support `--exclude` for globs.
-- Output: per-file planned updates and a final summary; respect `--dry-run`/`--yes` consistently.
+- Output: per-file planned updates and a final summary; respect `--dry-run`/`--yes`/`--write` consistently.
 - Rationale: monorepos and multi-workflow repos benefit from bulk pinning.

--- a/justfile
+++ b/justfile
@@ -13,6 +13,10 @@ pin-apply:
 pin-apply-yes:
 	go run main.go --yes {{workflow}}
 
+# Apply changes non-interactively using --write (alias of --yes)
+pin-apply-write:
+	go run main.go --write {{workflow}}
+
 # Run tests
 test:
 	go test ./...

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func getGitHubTokenFromHostsFile() (string, error) {
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [--expand-major] [--policy <policy>] [--yes] [--dry-run] <workflow-file>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [--expand-major] [--policy <policy>] [--yes|--write] [--dry-run] <workflow-file>\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Example: %s --policy same-major --yes .github/workflows/update_cli_docs.yml\n", os.Args[0])
 	}
 	// Toggle: when a moving major tag (e.g., v4 or 4) is detected, expand the displayed version
@@ -215,11 +215,14 @@ func main() {
 	expandMajorFlag := flag.Bool("expand-major", false, "Expand moving major tags (vN or N) to full semver in the version comment")
 	policyFlag := flag.String("policy", "major", "Update policy: major (default), same-major, requested")
 	yesFlag := flag.Bool("yes", false, "Apply changes without confirmation prompt")
+	writeFlag := flag.Bool("write", false, "Apply changes without confirmation prompt (alias of --yes)")
 	dryRunFlag := flag.Bool("dry-run", false, "Preview planned updates and exit without writing")
 	flag.Parse()
 
-	if *dryRunFlag && *yesFlag {
-		fmt.Fprintf(os.Stderr, "Error: --dry-run cannot be used with --yes\n")
+	nonInteractiveApply := *yesFlag || *writeFlag
+
+	if *dryRunFlag && nonInteractiveApply {
+		fmt.Fprintf(os.Stderr, "Error: --dry-run cannot be used with --yes/--write\n")
 		os.Exit(1)
 	}
 
@@ -305,7 +308,7 @@ func main() {
 
 	fmt.Println()
 	// If --yes is set, skip the prompt and apply immediately
-	if !*yesFlag {
+	if !nonInteractiveApply {
 		if !promptConfirmation(bold("Apply changes?") + " [y/N] ") {
 			fmt.Println(bold("\nNo changes applied."))
 			return


### PR DESCRIPTION
Add `--write` as an alias for `--yes` to provide an alternative flag for non-interactive application.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7f80ec3-8d5b-4b30-acff-e0df4b1fb930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7f80ec3-8d5b-4b30-acff-e0df4b1fb930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

